### PR TITLE
Add null and empty checks for word meanings and examples in layouts

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: "en-US"
+
+reviews:
+  profile: "assertive"
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - "develop"
+
+  # Path-specific instructions for Android/Kotlin code reviews
+  path_instructions:
+    - path: "**/*.kt"
+      instructions: |
+        As a Senior Software Architect, review this Kotlin code against Google's Modern Android Development (MAD) and JetBrains' Kotlin Coding Conventions. Prioritize the following:
+
+        1. **Clean Architecture & SOLID**:
+           - Enforce strict separation of concerns (UI, Domain, Data layers).
+           - Ensure the 'Dependency Inversion Principle' is followed; high-level modules should not depend on low-level modules.
+           - Flag any business logic found in UI controllers (Activities/Fragments).
+
+        2. **Memory & Performance (Google Best Practices)**:
+           - Identify 'Context' leaks or improper 'Lifecycle' handling.
+           - Check for efficient 'Coroutine' usage (avoid GlobalScope; ensure 'Dispatchers.IO' for disk/network and 'Dispatchers.Main' for UI).
+           - Verify that 'ViewModel' does not hold references to Views or Lifecycle-bound classes.
+
+        3. **Idiomatic Kotlin (JetBrains Standards)**:
+           - Ensure use of 'apply', 'let', 'also', and 'run' where appropriate.
+           - Enforce 'val' over 'var' to promote immutability.
+           - Flag 'null-safety' anti-patterns (e.g., unnecessary '!!' or complex nested 'if-null' checks).
+
+        4. **Resource & Asset Management**:
+           - Strict ban on hardcoded strings, dimensions, or colors.
+           - Ensure all UI resources are extracted to the 'res' directory for localization readiness.
+
+        5. **OOP & Design Patterns**:
+           - Look for opportunities to use Creational, Structural, or Behavioral patterns (e.g., Factory, Observer, Repository).
+           - Ensure proper use of Kotlin 'interfaces' and 'sealed classes' for state management (MVI/MVVM).
+
+        6. **Testing & Maintainability**:
+           - Flag code that is "untestable" (e.g., hidden dependencies or static singletons).
+           - Ensure variable naming is descriptive and follows the standard 'camelCase' convention.
+
+    - path: "**/*.java"
+      instructions: |
+        Apply the same Android development best practices as Kotlin files, adapted for Java:
+        - Check for proper lifecycle management
+        - Verify memory leak prevention
+        - Ensure resource externalization
+        - Flag anti-patterns and suggest modern alternatives

--- a/app/src/main/res/layout-sw600dp/activity_home.xml
+++ b/app/src/main/res/layout-sw600dp/activity_home.xml
@@ -582,8 +582,8 @@
                             android:layout_marginBottom="@dimen/margin_small"
                             android:ellipsize="end"
                             android:maxLines="4"
-                            android:text="@{mainViewModel.wordOfTheDay.meanings.size() > 0 ? mainViewModel.wordOfTheDay.meanings.get(0) : ``}"
-                            android:visibility="@{mainViewModel.wordOfTheDay.meanings.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}" />
+                            android:text="@{mainViewModel.wordOfTheDay.meanings!=null &amp;&amp; mainViewModel.wordOfTheDay.meanings.size() > 0 ? mainViewModel.wordOfTheDay.meanings.get(0) : ``}"
+                            android:visibility="@{mainViewModel.wordOfTheDay.meanings!=null &amp;&amp; mainViewModel.wordOfTheDay.meanings.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}" />
 
                         <LinearLayout
                             android:layout_width="wrap_content"

--- a/app/src/main/res/layout-sw600dp/activity_home.xml
+++ b/app/src/main/res/layout-sw600dp/activity_home.xml
@@ -582,13 +582,15 @@
                             android:layout_marginBottom="@dimen/margin_small"
                             android:ellipsize="end"
                             android:maxLines="4"
-                            android:text="@{mainViewModel.wordOfTheDay.meanings[0]}" />
+                            android:text="@{mainViewModel.wordOfTheDay.meanings.size() > 0 ? mainViewModel.wordOfTheDay.meanings.get(0) : ``}"
+                            android:visibility="@{mainViewModel.wordOfTheDay.meanings.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}" />
 
                         <LinearLayout
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="@dimen/margin_small"
-                            android:orientation="vertical">
+                            android:orientation="vertical"
+                            android:visibility="@{mainViewModel.wordOfTheDay.examples.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}">
 
                             <TextView
                                 style="@style/AppTheme.SubTitleTextStyle"
@@ -605,7 +607,7 @@
                                 android:layout_height="wrap_content"
                                 android:ellipsize="end"
                                 android:maxLines="6"
-                                android:text="@{mainViewModel.wordOfTheDay.examples[0]}" />
+                                android:text="@{mainViewModel.wordOfTheDay.examples.size() > 0 ? mainViewModel.wordOfTheDay.examples.get(0) : ``}" />
                         </LinearLayout>
 
                         <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout-sw600dp/activity_home.xml
+++ b/app/src/main/res/layout-sw600dp/activity_home.xml
@@ -590,7 +590,7 @@
                             android:layout_height="wrap_content"
                             android:layout_marginTop="@dimen/margin_small"
                             android:orientation="vertical"
-                            android:visibility="@{mainViewModel.wordOfTheDay.examples.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}">
+                            android:visibility="@{mainViewModel.wordOfTheDay.examples!=null &amp;&amp; mainViewModel.wordOfTheDay.examples.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}">
 
                             <TextView
                                 style="@style/AppTheme.SubTitleTextStyle"
@@ -607,7 +607,7 @@
                                 android:layout_height="wrap_content"
                                 android:ellipsize="end"
                                 android:maxLines="6"
-                                android:text="@{mainViewModel.wordOfTheDay.examples.size() > 0 ? mainViewModel.wordOfTheDay.examples.get(0) : ``}" />
+                                android:text="@{mainViewModel.wordOfTheDay.examples!=null &amp;&amp; mainViewModel.wordOfTheDay.examples.size() > 0 ? mainViewModel.wordOfTheDay.examples.get(0) : ``}" />
                         </LinearLayout>
 
                         <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -583,7 +583,8 @@
                             android:layout_marginBottom="@dimen/margin_small"
                             android:ellipsize="end"
                             android:maxLines="2"
-                            android:text="@{mainViewModel.wordOfTheDay.meanings[0]}" />
+                            android:text="@{mainViewModel.wordOfTheDay.meanings.size() > 0 ? mainViewModel.wordOfTheDay.meanings.get(0) : ``}"
+                            android:visibility="@{mainViewModel.wordOfTheDay.meanings.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}" />
 
                         <LinearLayout
                             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -583,14 +583,15 @@
                             android:layout_marginBottom="@dimen/margin_small"
                             android:ellipsize="end"
                             android:maxLines="2"
-                            android:text="@{mainViewModel.wordOfTheDay.meanings.size() > 0 ? mainViewModel.wordOfTheDay.meanings.get(0) : ``}"
-                            android:visibility="@{mainViewModel.wordOfTheDay.meanings.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}" />
+                            android:text="@{mainViewModel.wordOfTheDay.meanings!=null &amp;&amp; mainViewModel.wordOfTheDay.meanings.size() > 0 ? mainViewModel.wordOfTheDay.meanings.get(0) : ``}"
+                            android:visibility="@{mainViewModel.wordOfTheDay.meanings!=null &amp;&amp; mainViewModel.wordOfTheDay.meanings.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}" />
 
                         <LinearLayout
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="@dimen/margin_small"
-                            android:orientation="vertical">
+                            android:orientation="vertical"
+                            android:visibility="@{mainViewModel.wordOfTheDay.examples!=null &amp;&amp; mainViewModel.wordOfTheDay.examples.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}">
 
                             <TextView
                                 style="@style/AppTheme.SubTitleTextStyle"
@@ -607,7 +608,7 @@
                                 android:layout_height="wrap_content"
                                 android:ellipsize="end"
                                 android:maxLines="3"
-                                android:text="@{mainViewModel.wordOfTheDay.examples[0]}" />
+                                android:text="@{mainViewModel.wordOfTheDay.examples!=null &amp;&amp; mainViewModel.wordOfTheDay.examples.size() > 0 ? mainViewModel.wordOfTheDay.examples.get(0) : ``}" />
                         </LinearLayout>
 
                         <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/item_bookmarked_word_layout.xml
+++ b/app/src/main/res/layout/item_bookmarked_word_layout.xml
@@ -68,14 +68,14 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/margin_small"
-                android:text="@{word.meanings.size() > 0 ? word.meanings.get(0) : ``}"
-                android:visibility="@{word.meanings.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}" />
+                android:text="@{word.meanings!=null &amp;&amp; word.meanings.size() > 0 ? word.meanings.get(0) : ``}"
+                android:visibility="@{word.meanings!=null &amp;&amp; word.meanings.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
-                app:isGone="@{word.synonyms.size()==0 &amp;&amp; word.antonyms.size()==0}">
+                app:isGone="@{word.synonyms!=null &amp;&amp; word.synonyms.size()==0 &amp;&amp; word.antonyms.size()==0}">
 
                 <TextView
                     android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_bookmarked_word_layout.xml
+++ b/app/src/main/res/layout/item_bookmarked_word_layout.xml
@@ -68,7 +68,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/margin_small"
-                android:text="@{word.meanings.get(0)}" />
+                android:text="@{word.meanings.size() > 0 ? word.meanings.get(0) : ``}"
+                android:visibility="@{word.meanings.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}" />
 
             <LinearLayout
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/item_recap_word_layout.xml
+++ b/app/src/main/res/layout/item_recap_word_layout.xml
@@ -50,15 +50,15 @@
                 style="@style/AppTheme.SmallTextStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:visibility="@{word.meanings.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}"
-                android:text="@{word.meanings.size() > 0 ? word.meanings.get(0) : ``}" />
+                android:visibility="@{word.meanings!=null &amp;&amp; word.meanings.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}"
+                android:text="@{word.meanings!=null &amp;&amp; word.meanings.size() > 0 ? word.meanings.get(0) : ``}" />
 
             <TextView
                 style="@style/AppTheme.SmallTextStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:visibility="@{word.examples.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}"
-                android:text="@{word.examples.size() > 0 ? word.examples.get(0) : ``}"
+                android:visibility="@{word.examples!=null &amp;&amp; word.examples.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}"
+                android:text="@{word.examples!=null &amp;&amp;word.examples.size() > 0 ? word.examples.get(0) : ``}"
                 android:textStyle="italic" />
         </LinearLayout>
 

--- a/app/src/main/res/layout/item_recap_word_layout.xml
+++ b/app/src/main/res/layout/item_recap_word_layout.xml
@@ -50,13 +50,15 @@
                 style="@style/AppTheme.SmallTextStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@{word.meanings.get(0)}" />
+                android:visibility="@{word.meanings.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}"
+                android:text="@{word.meanings.size() > 0 ? word.meanings.get(0) : ``}" />
 
             <TextView
                 style="@style/AppTheme.SmallTextStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@{word.examples.get(0)}"
+                android:visibility="@{word.examples.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}"
+                android:text="@{word.examples.size() > 0 ? word.examples.get(0) : ``}"
                 android:textStyle="italic" />
         </LinearLayout>
 

--- a/app/src/main/res/layout/item_word_list_layout.xml
+++ b/app/src/main/res/layout/item_word_list_layout.xml
@@ -89,7 +89,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="@dimen/margin_small"
-                    android:text="@{wordItem.word.meanings.get(0)}" />
+                    android:visibility="@{wordItem.word.meanings.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}"
+                    android:text="@{wordItem.word.meanings.size() > 0 ? wordItem.word.meanings.get(0) : ``}" />
 
                 <LinearLayout
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/item_word_list_layout.xml
+++ b/app/src/main/res/layout/item_word_list_layout.xml
@@ -89,14 +89,14 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="@dimen/margin_small"
-                    android:visibility="@{wordItem.word.meanings.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}"
-                    android:text="@{wordItem.word.meanings.size() > 0 ? wordItem.word.meanings.get(0) : ``}" />
+                    android:visibility="@{wordItem.word.meanings!=null &amp;&amp; wordItem.word.meanings.size() > 0 ? android.view.View.VISIBLE : android.view.View.GONE}"
+                    android:text="@{wordItem.word.meanings!=null &amp;&amp; wordItem.word.meanings.size() > 0 ? wordItem.word.meanings.get(0) : ``}" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal"
-                    app:isGone="@{wordItem.word.synonyms.size()==0 &amp;&amp; wordItem.word.antonyms.size()==0}">
+                    app:isGone="@{wordItem.word.synonyms!=null &amp;&amp; wordItem.word.synonyms.size()==0 &amp;&amp; wordItem.word.antonyms!=null &amp;&amp; wordItem.word.antonyms.size()==0}">
 
                     <TextView
                         android:layout_width="wrap_content"


### PR DESCRIPTION
This commit adds safety checks to data binding expressions across multiple layout files to prevent potential IndexOutOfBoundsExceptions when a word has no meanings or examples.

Key changes include:
* **Safety Checks**: Updated XML layouts to check if `meanings` or `examples` lists are non-empty before attempting to access the first element.
* **Conditional Visibility**: Added `android:visibility` logic to hide TextViews or parent containers if the corresponding data (meanings/examples) is missing.
* **Affected Layouts**:
    * `item_bookmarked_word_layout.xml` (Bookmarked words list)
    * `item_word_list_layout.xml` (General word list)
    * `item_recap_word_layout.xml` (Recap features)
    * `activity_home.xml` and `activity_home.xml (sw600dp)` (Word of the Day card)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes and improved stability when words lack meanings or examples.
  * Improved UI so meaning/example fields and related sections are hidden when data is missing, avoiding empty placeholders and ensuring cleaner layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->